### PR TITLE
Update Workshop slides to be Python3-compatible

### DIFF
--- a/class1.html
+++ b/class1.html
@@ -263,16 +263,16 @@
             <div class='box--small'><pre><code contenteditable class="python" style="min-height: 50px;">
 >>> a = 2
 >>> b = 3
->>> print a + b
+>>> print (a + b)
 5
 >>> c = a + b
->>> print c * 2
+>>> print (c * 2)
 10
             </code></pre></div>
             <div class='box--small'><pre><code contenteditable class="python" style="min-height: 50px;">
 >>> a = 0
 >>> a = a + .5
->>> print a
+>>> print (a)
 0.5
 >>> a
 0.5
@@ -301,18 +301,18 @@
 a = 'Hello '
 b = 'World'
 c = a + b
-print c
+print (c)
             </code></pre></div>
             <div class="box--small"><pre><code contenteditable class="python" style="min-height: 50px;">
 a = "Spam "
 b = a * 4
-print b
+print (b)
             </code></pre></div>
             <div class="box--small"><pre><code contenteditable class="python" style="min-height: 50px;">
 a = 'spam '
 b = 'eggs'
 c = a * 4 + b
-print c
+print (c)
             </code></pre></div>
         </section>
 
@@ -326,14 +326,14 @@ print c
               <li class="fragment"><code>type()</code> is a <strong>function</strong>. We <em>call</em> it by using parenthesis and pass it an object by placing the object inside the parenthesis
             <pre><code contenteditable class="python" style="min-height: 50px;">
 a = 4
-print type(a)
-print type(4)
+print (type(a))
+print (type(4))
 
-print type(3.14)
+print (type(3.14))
 
 b = 'spam, again'
-print type(b)
-print type("But I don't like spam")
+print (type(b))
+print (type("But I don't like spam"))
             </code></pre>
 
               </li>
@@ -349,7 +349,7 @@ print type("But I don't like spam")
                 <li>What happens if we try to use division or subtraction with a string?</li>
             </ul>
         <pre><code contenteditable class="python" style="min-height: 50px;">
->>> print "Spam" / "eggs"
+>>> print ("Spam" / "eggs")
 Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
 TypeError: unsupported operand type(s) for /: 'str' and 'str'
@@ -377,7 +377,7 @@ TypeError: unsupported operand type(s) for /: 'str' and 'str'
 
 # NameError - Using a name that hasn't been defined yet
 a = 5
-print b
+print (b)
 b = 10
 
 # TypeError - Using an object in a way that its type does not support
@@ -461,7 +461,7 @@ $ pwd
                 <li class="fragment">Click "File", then "Open". Navigate to the <code>gdi-intro-python</code> <strong>folder</strong> we just created and click "Open"</li>
                 <li class="fragment">In the text editor, enter the following:
             <pre><code contenteditable class="python" style="min-height: 50px;">
-print 'Hello World!'
+print ('Hello World!')
             </code></pre>
                 </li>
                 <li class="fragment">Click "File", then "Save As...". Type "class1.py" and click "Save".</li>
@@ -479,7 +479,7 @@ print 'Hello World!'
 name = raw_input("What is your name?")
 age = raw_input("How old are you?")
 age_int = int(age)
-print "Your name is" + name + " and you are " age + " years old."
+print ("Your name is" + name + " and you are " age + " years old.")
 
 type(age)
 type(age_int)

--- a/class1.html
+++ b/class1.html
@@ -479,7 +479,7 @@ print ('Hello World!')
 name = input("What is your name?")
 age = input("How old are you?")
 age_int = int(age)
-print ("Your name is" + name + " and you are " age + " years old.")
+print ("Your name is " + name + " and you are " + age + " years old.")
 
 type(age)
 type(age_int)

--- a/class1.html
+++ b/class1.html
@@ -473,11 +473,11 @@ print ('Hello World!')
 
         <section>
             <h3>User Input</h3>
-            <p class="copy--small box--small">To obtain user input, use <code>raw_input()</code></p>
+            <p class="copy--small box--small">To obtain user input, use <code>input()</code></p>
             <p class="copy--small box--small">Change the class1.py text to the following and run it again</p>
             <pre><code contenteditable class="python" style="min-height: 50px;">
-name = raw_input("What is your name?")
-age = raw_input("How old are you?")
+name = input("What is your name?")
+age = input("How old are you?")
 age_int = int(age)
 print ("Your name is" + name + " and you are " age + " years old.")
 
@@ -490,7 +490,7 @@ type(age_int)
       <!-- Let's develop it: 15 minutes -->
       <section>
           <h3>Let's Develop It!</h3>
-          <p class="copy--small box">Write your own program that uses raw_input<br/>and does something else with the value</p>
+          <p class="copy--small box">Write your own program that uses input<br/>and does something else with the value</p>
           <p class="copy--xsmall box">You can use float() to treat the input as a number if you need a number,<br/>or use the input directly as a string.</p>
       </section>
 

--- a/class2.html
+++ b/class2.html
@@ -221,7 +221,7 @@ else:
             <p class="copy--small box--small">Write this into your text editor and save the file as class2.py in your gdi-intro-python folder.
             <pre><code contenteditable class=" python">
 print ("It's your birthday!")
-answer = raw_input("How old are you? ")
+answer = input("How old are you? ")
 age = int(answer)
 if answer &lt; 21:
     print ("You may not have a beer, but here's some juice!")
@@ -252,12 +252,12 @@ else:
             <div class="fragment"><p class="box--small copy--small">Edit your python file to contain the following:</p>
             <pre><code contenteditable class="small python">
 print ("It's your birthday!")
-answer = raw_input("How old are you? ")
+answer = input("How old are you? ")
 age = int(answer)
 if answer &lt; 21:
     print ("You may not have a beer, but here's some juice!")
 else:
-    beers = raw_input("How many beers do you want?")
+    beers = input("How many beers do you want?")
     beers = int(beers)
     if beers > 3:
         print ("Oops, you're drunk!")
@@ -280,7 +280,7 @@ print ("A vicious warg is chasing you.")
 print ("Options:")
 print ("1 - Hide in the cave.")
 print ("2 - Climb a tree.")
-input_value = raw_input("Enter choice:")
+input_value = input("Enter choice:")
 if input_value == '1':
     print ('You hide in a cave.')
     print ('The warg finds you and injures your leg with its claws')
@@ -302,10 +302,10 @@ else:
           <p class="box--small copy--small fragment">The repeated execution of a set of statements is called <strong>iteration</strong></p>
           <div class="fragment"><p class="box--small copy--small">One way to acheive this, is with the <strong>while</strong> loop.</p>
             <pre><code contenteditable class=" small python">
-user_input = raw_input('would you like to quit? (y/n) ')
+user_input = input('would you like to quit? (y/n) ')
 
 while user_input != 'y':
-    user_input = raw_input('would you like to quit? (y/n) ')
+    user_input = input('would you like to quit? (y/n) ')
 
 print ('quitters never win!')
           </code></pre></div>
@@ -316,7 +316,7 @@ print ('quitters never win!')
             <h3>While loops</h3>
             <p class="box--small copy--small">Consider the following example that uses iteration with a while loop</p>
             <div class="fragment"><pre><code contenteditable class="small python">
-input_value = raw_input('Enter a positive integer:') 
+input_value = input('Enter a positive integer:') 
 user_number = int(input_value)
 while user_number > 0:
     print ("The user's number is still positive, let's subtract 1")

--- a/class2.html
+++ b/class2.html
@@ -223,7 +223,7 @@ else:
 print ("It's your birthday!")
 answer = input("How old are you? ")
 age = int(answer)
-if answer &lt; 21:
+if age &lt; 21:
     print ("You may not have a beer, but here's some juice!")
 else:
     print ("Here's some beer!")

--- a/class2.html
+++ b/class2.html
@@ -345,23 +345,6 @@ print (costs)
         </section>
 
         <section>
-          <h3>Range</h3>
-          <p class="fragment box--small copy--small">What do you think the following functions output?</p>
-          <pre><code contenteditable class="small fragment python">
-  range(5)
-          </code></pre>
-          <pre><code contenteditable class="small fragment python">
-  range(5, 10)
-          </code></pre>
-          <pre><code contenteditable class="small fragment python">
-  range(10, 20, 2)
-          </code></pre>
-          <pre><code contenteditable class="small fragment python">
-  range(20, 8, -2)
-          </code></pre>
-        </section>
-
-        <section>
             <h3>For loops continued</h3>
             <p class="copy--small box--small">Let's examine the example carefully</p>
             <pre><code contenteditable class="small python">

--- a/class2.html
+++ b/class2.html
@@ -254,7 +254,7 @@ else:
 print ("It's your birthday!")
 answer = input("How old are you? ")
 age = int(answer)
-if answer &lt; 21:
+if age &lt; 21:
     print ("You may not have a beer, but here's some juice!")
 else:
     beers = input("How many beers do you want?")

--- a/class2.html
+++ b/class2.html
@@ -66,10 +66,10 @@
             <pre class="fragment"><code contenteditable class="python" style="min-height: 50px;">
 a = 5
 b = 5
-print a == b
+print (a == b)
 c = 3
-print a == c
-print c &lt; a
+print (a == c)
+print (c &lt; a)
             </code></pre>
         </section>
 
@@ -105,9 +105,9 @@ print c &lt; a
             <pre class=""><code contenteditable class="python" style="min-height: 50px;">
 a = 3
 b = 4
-print a != b
-print a <= 3
-print a >= 4
+print (a != b)
+print (a <= 3)
+print (a >= 4)
             </code></pre>
             <p class="copy--xsmall">Remember: Equals does not equal "equals equals"</p>
         </section>
@@ -138,7 +138,7 @@ words = [0, 'list', 'of', 3, 'strings', 'and', 'numbers']
 to_do_list = []
 to_do_list.append('buy soy milk')
 to_do_list.append('learn python')
-print to_do_list
+print (to_do_list)
             </code></pre></div>
             <p class="copy--small box--small fragment">Therefore, lists are <strong>mutable</strong></p>
             <p class="copy--small box--small fragment">This means that a list can change values<br/>during the duration of a program</p>
@@ -151,7 +151,7 @@ print to_do_list
             <div class="fragment"><p class="copy--small box--small">To index on a list, follow it immediately with <code>[index]</code>.</p>
             <pre><code contenteditable class="small python">
 numbers = [10, 20, 30]
-print numbers[0]
+print (numbers[0])
             </code></pre></div>
             <p class="copy--small box--small fragment">Lists (and other data types) start at the number 0 and count up.</p>
         </section>
@@ -166,13 +166,13 @@ print numbers[0]
 to_do_list = [
     'learn python', 'read email', 'make lunch',
 ]
-print len(to_do_list)
+print (len(to_do_list))
 
-print to_do_list[0]
-print to_do_list[2]
+print (to_do_list[0])
+print (to_do_list[2])
 
-print to_do_list[len(to_do_list)]
-print to_do_list[len(to_do_list) - 1]
+print (to_do_list[len(to_do_list)])
+print (to_do_list[len(to_do_list) - 1])
             </code></pre>
             <p class="box--small copy--xsmall fragment">An IndexError results if an index exceeds the length of the list minus 1</p>
         </section>
@@ -196,7 +196,7 @@ print to_do_list[len(to_do_list) - 1]
             <p class="copy--xsmall">We achieve this using <strong>if</strong> statements</p>
             <pre><code contenteditable class="small python">
     if x == 5:
-        print 'x is equal to 5'
+        print ('x is equal to 5')
             </code></pre></div>
 
         </section>
@@ -206,9 +206,9 @@ print to_do_list[len(to_do_list) - 1]
             <p class="copy--xsmall">We often want a different block to execute if the statement is false.<br/>This can be accomplished using <strong>else</strong></p>
             <pre><code contenteditable class="small python">
 if x == 5:
-    print 'x is equal to 5'
+    print ('x is equal to 5')
 else:
-    print 'x is not equal to 5'
+    print ('x is not equal to 5')
             </code></pre>
             </div>
         </section>
@@ -220,14 +220,14 @@ else:
             <div class="fragment">
             <p class="copy--small box--small">Write this into your text editor and save the file as class2.py in your gdi-intro-python folder.
             <pre><code contenteditable class=" python">
-print "It's your birthday!"
+print ("It's your birthday!")
 answer = raw_input("How old are you? ")
 age = int(answer)
 if answer &lt; 21:
-    print "You may not have a beer, but here's some juice!"
+    print ("You may not have a beer, but here's some juice!")
 else:
-    print "Here's some beer!"
-print "Happy birthday!"
+    print ("Here's some beer!")
+print ("Happy birthday!")
             </code></pre></div>
         </section>
 
@@ -237,11 +237,11 @@ print "Happy birthday!"
             <div class="fragment"><p class="box--small copy--small ">Chained conditionals use <code>elif</code> as an additonal check after the preceeding <code>if</code> predicate was False. For example:</p>
             <pre><code contenteditable class=" python small">
 if x &lt; 0:
-    print "x is negative"
+    print ("x is negative")
 elif x &gt; 0:
-    print "x is positive"
+    print ("x is positive")
 else:
-    print "x is 0"
+    print ("x is 0")
             </code></pre></div>
         </section>
 
@@ -251,21 +251,21 @@ else:
             <p class="box--small copy--small fragment">Nested conditionals occur inside of other conditionals, and are indented over once more. When the code block is complete you move back.</p>
             <div class="fragment"><p class="box--small copy--small">Edit your python file to contain the following:</p>
             <pre><code contenteditable class="small python">
-print "It's your birthday!"
+print ("It's your birthday!")
 answer = raw_input("How old are you? ")
 age = int(answer)
 if answer &lt; 21:
-    print "You may not have a beer, but here's some juice!"
+    print ("You may not have a beer, but here's some juice!")
 else:
     beers = raw_input("How many beers do you want?")
     beers = int(beers)
     if beers > 3:
-        print "Oops, you're drunk!"
+        print ("Oops, you're drunk!")
     elif beers > 1:
-        print "You got a little tipsy"
+        print ("You got a little tipsy")
     else:
-        print "Looks like you're the designated driver"
-print "Happy birthday!"
+        print ("Looks like you're the designated driver")
+print ("Happy birthday!")
             </code></pre></div>
         </section>
 
@@ -276,20 +276,20 @@ print "Happy birthday!"
             <p class="box--small copy--small">The code below is an example:</p>
             <pre><code contenteditable class=" python">
 health = 100
-print "A vicious warg is chasing you."
-print "Options:"
-print "1 - Hide in the cave."
-print "2 - Climb a tree."
+print ("A vicious warg is chasing you.")
+print ("Options:")
+print ("1 - Hide in the cave.")
+print ("2 - Climb a tree.")
 input_value = raw_input("Enter choice:")
 if input_value == '1':
-    print 'You hide in a cave.'
-    print 'The warg finds you and injures your leg with its claws'
+    print ('You hide in a cave.')
+    print ('The warg finds you and injures your leg with its claws')
     health = health - 10
 elif input_value == '2':
-    print 'You climb a tree.'
-    print 'The warg eventually looses interest and wanders off'
+    print ('You climb a tree.')
+    print ('The warg eventually looses interest and wanders off')
 else:
-    print 'Invalid option.'
+    print ('Invalid option.')
             </code></pre>
         </section>
 
@@ -307,7 +307,7 @@ user_input = raw_input('would you like to quit? (y/n) ')
 while user_input != 'y':
     user_input = raw_input('would you like to quit? (y/n) ')
 
-print 'quitters never win!'
+print ('quitters never win!')
           </code></pre></div>
           <p class="box--small copy--small fragment">As long as the while statement evaluates to True, the code block beneath it is repeated.</p>
         </section>
@@ -319,9 +319,9 @@ print 'quitters never win!'
 input_value = raw_input('Enter a positive integer:') 
 user_number = int(input_value)
 while user_number > 0:
-    print "The user's number is still positive, let's subtract 1"
+    print ("The user's number is still positive, let's subtract 1")
     user_number = user_number - 1
-print "User's number is no longer positive."
+print ("User's number is no longer positive.")
                                 </code></pre></div>
             <p class="copy--small box--small fragment">This implementation does not work for negative numbers. Why?</p>
         </section>
@@ -340,7 +340,7 @@ costs = []
 for price in prices:
     costs.append(price + shipping_cost)
 
-print costs
+print (costs)
             </code></pre></div>
         </section>
 
@@ -366,8 +366,8 @@ print costs
             <p class="copy--small box--small">Let's examine the example carefully</p>
             <pre><code contenteditable class="small python">
 for number in range(5):
-    print "The current number is:"
-    print number
+    print ("The current number is:")
+    print (number)
             </code></pre>
             <p class="fragment copy--small box--small">This for loop has three parts:</p>
             <ul class="list--tall copy--xsmall">
@@ -385,8 +385,8 @@ for number in range(5):
         <em>processing,</em> not <em>understanding.</em></p>
         <pre><code contenteditable class="small python">
 for moose in range(5):
-    print "The current number is:"
-    print moose
+    print ("The current number is:")
+    print (moose)
         </code></pre></div>
         </section>
 

--- a/class3.html
+++ b/class3.html
@@ -64,7 +64,7 @@
             <div class="fragment"><p class="copy--small box--small ">We have already made a function call<br/>when using the <code>type</code>, <code>int</code>, or <code>float</code> functions</p>
             <pre><code contenteditable class=" python small">
 a = '3'
-print type(a)
+print (type(a))
 a = float(a)
             </code></pre></div>
         </section>
@@ -73,7 +73,7 @@ a = float(a)
             <h3>Function calls</h3>
             <pre><code contenteditable class="small python">
 a = 3
-print type(a)
+print (type(a))
             </code></pre>
             <p class="copy--small box--small">A function can take <strong>arguments</strong></p>
             <p class="copy--small box--small">In the example above, the variable <code>a</code> is passed<br/>as an argument to the function <code>type</code></p>
@@ -91,7 +91,7 @@ str(32)
             <p class="copy--small box--small">The following example is a <strong>function definition</strong>.<br/>This allows us to create our own functions</p>
             <pre><code contenteditable class="python">
 def print_plus_5(x):
-    print x + 5
+    print (x + 5)
             </code></pre>
             <p class="copy--small box--small fragment">The function definition has the following parts</p>
             <ul class="copy--xsmall box--small list--tall">
@@ -108,7 +108,7 @@ def print_plus_5(x):
             <div class="copy--small box--small fragment"><p>We just used x as our argument, but I can replace that with duck and the function will work the same</p>
             <pre><code contenteditable class="python">
 def print_plus_5(duck):
-    print duck + 5
+    print (duck + 5)
             </code></pre>
             <p class="copy--small box--small fragment">When naming your functions and your
             arguments, you should use terms based on the task at hand</p>
@@ -125,14 +125,14 @@ def plus_5(x):
     x + 5
 
 y = plus_5(4)
-print y
+print (y)
 
 #function with return
 def return_plus_5(x):
     return x + 5
 
 y = return_plus_5(4)
-print y
+print (y)
             </code></pre></div>
         </section>
 
@@ -141,7 +141,7 @@ print y
             <p class="copy--small box--small">A function does not have to take arguments,<br/>as in the following example:
             <pre><code contenteditable class="small python">
 def grass():
-    print 'The grass is green.'
+    print ('The grass is green.')
 
 grass()
             </code></pre>
@@ -156,7 +156,7 @@ def personal_info(name, age):
     return "My name is " + name + " and I am " + str(age) + " years old."
 
 my_information = personal_info("Amy", 26)
-print my_information
+print (my_information)
             </code></pre>
         </section>
 
@@ -187,10 +187,10 @@ def get_email_address():
     return raw_input("What is your address?")
 
 def register():
-    print "Please fill out the following information to register:"
+    print ("Please fill out the following information to register:")
     name = get_name()
     email = get_email_address()
-    print name, "is registered under the email address", email
+    print (name, "is registered under the email address", email)
             </code></pre></div>
         </section>
  
@@ -204,11 +204,11 @@ name = 'caleb'
 sentence = 'the quick brown fox did the thing with the thing'
 a_list = [1, 2, 3]
 
-print name.capitalize()
-print sentence.count('the')
+print (name.capitalize())
+print (sentence.count('the'))
 
 a_list.append(4)
-print a_list
+print (a_list)
             </code></pre></div>
         </section>
 
@@ -249,12 +249,12 @@ menu = {
     'baguette': 3,
 }
 
-print menu.keys()
-print menu.values()
-print menu.items()
-print menu.get('pizza')
-print menu.get('water')
-print menu.get('juice', 5)
+print (menu.keys())
+print (menu.values())
+print (menu.items())
+print (menu.get('pizza'))
+print (menu.get('water'))
+print (menu.get('juice', 5))
             </code></pre>
             <p class="box--small copy--small">If you aren't certain a key is present, you can use the <code>get</code> method</p>
             <p class=" box--small copy--small"><code>get</code> will return None if the key isn't present.</p>
@@ -267,11 +267,11 @@ print menu.get('juice', 5)
             <pre><code contenteditable class="small python">
 color = [255, 255, 0]
 if 0 in color:
-    print '0 is in the color'
+    print ('0 is in the color')
 
 menu = {'tofu': 4}
-print 'tofu' in menu
-print 4 in menu
+print ('tofu' in menu)
+print (4 in menu)
             </code></pre></div>
         </section>
 
@@ -302,31 +302,31 @@ print 4 in menu
             <h3>Examples of using Builtins</h3>
             <pre><code contenteditable class="python">
 # Using len() - Determines length
-print len([1, 2])
-print len("Hello")
+print (len([1, 2]))
+print (len("Hello"))
 
 # range() - Quickly creates a list of integers
-print range(5)
-print range(5, 10)
-print range(0, 10, 2)
+print (range(5))
+print (range(5, 10))
+print (range(0, 10, 2))
 
 # sorted() - Sort a given list
 grades = [93, 100, 60]
 grades = sorted(grades)
-print grades
+print (grades)
             </code></pre>
         </section>
 
         <section>
             <h3>String Formatting Operators</h3>
             <pre><code contenteditable class="python">
-print 'To Do:'
+print ('To Do:')
 to_dos = ['work', 'sleep', 'work']
 for item in to_dos:
-    print '%s' %(item)
+    print ('%s' %(item))
 
 name = 'Sally'
-print 'Her name is {}'.format(name)
+print ('Her name is {}'.format(name))
             </code></pre>
         </section>
 

--- a/class3.html
+++ b/class3.html
@@ -181,10 +181,10 @@ print (my_information)
             <p class="copy--small box--small fragment"><strong>Function composition</strong> is when the <strong>output</strong> of one function <strong>acts as the input</strong> of another</p>
             <div class="fragment"><pre><code contenteditable class=" python">
 def get_name():
-    return raw_input("What is your name?")
+    return input("What is your name?")
 
 def get_email_address():
-    return raw_input("What is your address?")
+    return input("What is your address?")
 
 def register():
     print ("Please fill out the following information to register:")

--- a/class3.html
+++ b/class3.html
@@ -301,11 +301,6 @@ print (4 in menu)
 print (len([1, 2]))
 print (len("Hello"))
 
-# range() - Quickly creates a list of integers
-print (range(5))
-print (range(5, 10))
-print (range(0, 10, 2))
-
 # sorted() - Sort a given list
 grades = [93, 100, 60]
 grades = sorted(grades)

--- a/class3.html
+++ b/class3.html
@@ -284,10 +284,6 @@ print (4 in menu)
                     <td>Given a data type, return its length</td>
                 </tr>
                 <tr>
-                    <td><code>range()</code></td>
-                    <td>Create a list of integers in the range provided.</td>
-                </tr>
-                <tr>
                     <td><code>sorted()</code></td>
                     <td>Given a data type, returns a sorted copy of that data type</td>
                 </tr>

--- a/class4.html
+++ b/class4.html
@@ -61,11 +61,11 @@
             <pre class="fragment"><code class="python">
 >>> list_a = [0, 3, 2, 0, 2, 7]
 >>> set_a = set(list_a)
->>> print set_a
+>>> print (set_a)
 set([0, 2, 3, 7])
 
 >>> set_b = {1, 2, 1, 3}
->>> print set_b
+>>> print (set_b)
 set([1, 2, 3])
             </code></pre>
             <p class="copy--small fragment">Sets have an add method, which like append for lists, adds an element to a set.</p>
@@ -100,11 +100,11 @@ family_shopping_list.append(mary_shopping_list)
 family_shopping_list.append(fran_shopping_list)
 family_shopping_list.append(bob_shopping_list)
 
-print family_shopping_list
+print (family_shopping_list)
 
 for shop_list in family_shopping_list:
     for food_item in shop_list:
-        print food_item
+        print (food_item)
             </code></pre>
             <p class="copy--small box--small fragment">What if we want to <strong>flatten</strong> the family shopping list?</p>
             <p class="copy--small box--small fragment">What if we want the food items in the family shopping list to be unique?</p>
@@ -126,9 +126,9 @@ card_b = {
 
 hand = [card_a, card_b]
 
-print 'The hand contains:'
+print ('The hand contains:')
 for card in hand:
-    print 'A', card['number'], 'of', card['suit']
+    print ('A', card['number'], 'of', card['suit'])
             </code></pre>
         </section>
 
@@ -148,7 +148,7 @@ family_shopping_list = {
 }
 
 for name, shop_list in family_shopping_list.items():
-    print name, 'needs to buy: ', shop_list
+    print (name, 'needs to buy: ', shop_list)
 
 # Changing this later can be accomplished with
 family_shopping_list['fran'].append('strawberries')

--- a/class4.html
+++ b/class4.html
@@ -207,12 +207,15 @@ def heal(character, amount):
  
                     <p class="copy--small box--small">One commonly used, higher order function<br/>(that is a Python builtin) is called <strong>map</strong></p>
                     <pre><code contenteditable class=" python">
-# Define any function
-def sqaure(number):
-    return number ** 2
 
-# Pass the function to map along with an iterable
-squares = map(square, range(10))
+  # Define any function
+  def square(number):
+      return number ** 2
+  
+  # Pass the function to map along with an iterable
+  squares = list(map(square, range(10)))
+  
+  print(squares)
                     </code></pre>
                 </section>
 


### PR DESCRIPTION
Anyone in the workshop downloading Python for the first time was using Python3, and even those on Macs with Python2 installed preferred downloading and using the latest Python3 version, so I updated the slides to be compatible with Python 3.

Most of the changes were updating print() to have parentheses, changing raw_input() to input(), removing some range() references and updating map() to use list().